### PR TITLE
fix to correctly align the fills with the bars backgrounds in renderP…

### DIFF
--- a/addons/GlamourUI/helperfunctions.lua
+++ b/addons/GlamourUI/helperfunctions.lua
@@ -343,14 +343,14 @@ function renderPlayerStats(b, f, s, p, o)
         imgui.SetCursorPosX(o + 5);
         imgui.Image(b, {glamourUI.settings.playerStats.BarDim.l * glamourUI.settings.playerStats.gui_scale, glamourUI.settings.playerStats.BarDim.g * glamourUI.settings.playerStats.gui_scale});
         imgui.SameLine();
-        imgui.SetCursorPosX(o);
+        imgui.SetCursorPosX(o+5);
         if(p ~= nil)then
             imgui.Image(f, {(glamourUI.settings.playerStats.BarDim.l * glamourUI.settings.playerStats.gui_scale) * p / 100, glamourUI.settings.playerStats.BarDim.g * glamourUI.settings.playerStats.gui_scale});
         else
             imgui.Image(f, {glamourUI.settings.playerStats.BarDim.l  * (math.clamp((s / 1000), 0, 1) * glamourUI.settings.playerStats.gui_scale), glamourUI.settings.playerStats.BarDim.g * glamourUI.settings.playerStats.gui_scale});
         end
         imgui.SameLine();
-        imgui.SetCursorPosX(o + 5);
+        imgui.SetCursorPosX(o + 10);
         imgui.Text(tostring(s));
 end
 


### PR DESCRIPTION
This is a simple fix to correctly align the fill with it's background when using a theme for the player bar.
Before
![image](https://user-images.githubusercontent.com/61804473/211363898-0518ffc6-3a4d-49e6-b107-56cdd13ea3a5.png)
After
![image](https://user-images.githubusercontent.com/61804473/211363805-05ade2bf-d5d0-4db7-a2af-e60e5283b972.png)
